### PR TITLE
Fix broken tap syntax, def needed kwarg

### DIFF
--- a/lib/github-release.rb
+++ b/lib/github-release.rb
@@ -1,5 +1,5 @@
 class GithubPreReleaseDownloadStrategy < CurlDownloadStrategy
-  def fetch
+  def fetch(timeout: nil, **options)
     @url = getFromApi('releases')
       .find { |r| r['prerelease'] == true }
       .fetch('assets')


### PR DESCRIPTION
Fixes invalid syntax exception in tap
("def fetch")

Error: gem-XXXXX: Calling `def fetch`
in a subclass of `Formulary::
FormulaNamespaceYYYYYYYYYY::
RubyGemsDownloadStrategy` is disabled!
Use `def fetch(timeout: nil, **options)`
and output a warning when `options`
contains new unhandled options instead.